### PR TITLE
Support for multiple encoding formats

### DIFF
--- a/attachment_downloader/attachment_downloader.py
+++ b/attachment_downloader/attachment_downloader.py
@@ -38,7 +38,7 @@ class AttachmentDownloader:
 
 class MailMessage:
     def __init__(self, data):
-        self.msg = email.message_from_string(data.decode('utf-8'))
+        self.msg = email.message_from_string(self.decode(data))
         self.subject = self.msg['Subject']
         self.message_id = self.msg['message-id']
         self.raw_date = self.msg['Date']
@@ -66,3 +66,11 @@ class MailMessage:
             file_name = part.get_filename()
             if file_name == attachment_filename:
                 return part.get_payload(decode=True)
+
+    def decode(self, data):
+        encodings=('utf8', 'cp1252')
+        for encoding in encodings:
+            try:
+                return data.decode(encoding)
+            except:
+                pass


### PR DESCRIPTION
I had an issue with encoding like below.

```
2019-05-03 20:19:14,904 - INFO - Listing messages in folder: Inbox
Traceback (most recent call last):
  File "/anaconda3/bin/attachment-downloader", line 66, in <module>
    messages = downloader.list_messages(options.imap_folder)
  File "/anaconda3/lib/python3.6/site-packages/attachment_downloader/attachment_downloader.py", line 31, in list_messages
    messages.append(MailMessage(data[0][1]))
  File "/anaconda3/lib/python3.6/site-packages/attachment_downloader/attachment_downloader.py", line 41, in __init__
    self.msg = email.message_from_string(data.decode('utf-8'))
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x92 in position 13625: invalid start byte
```
So I implemented  a fix. This pull request supports utf-8 and windows encoding cp1252 which I think support most of the email scenarios.