### PR TITLE
Remove 'self' from staticmethod

### DIFF
--- a/attachment_downloader/attachment_downloader.py
+++ b/attachment_downloader/attachment_downloader.py
@@ -87,6 +87,6 @@ class MailMessage:
                 pass
 
     @staticmethod
-    def delete(self, conn, msg_id):
+    def delete(conn, msg_id):
         conn.delete_messages(msg_id)
         conn.expunge(msg_id)


### PR DESCRIPTION
A static method does not receive an implicit first argument[1].  This
causes the '--delete' CLI option to fail and the entire download exits
with an exception.

1: https://docs.python.org/3.7/library/functions.html#staticmethod