### PR TITLE
Fix password prompt

### DIFF
--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     password = options.password if options.password else getpass('IMAP Password: ')
 
     logging.info("Logging in to: '%s' as '%s'", options.host, options.username)
-    mail = Imbox(options.host, username=options.username, password=options.password)
+    mail = Imbox(options.host, username=options.username, password=password)
 
     folders = []
 


### PR DESCRIPTION
There was an error when imap password was not provided in call arguments. This PR fixes this.