### PR TITLE
Two new parser options for regex matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Usage:
       --imap-folder=IMAP_FOLDER
                             IMAP Folder to extract attachments from
       --subject-regex=SUBJECT_REGEX
-                            Regex that the subject must match against
+                            Regex that the subject must start with
+      --subject-regex-ignore-case
+                            Ignore case when matching subject
+      --subject-regex-match-anywhere
+                            Search entire subject for regex match
       --date-after=DATE_AFTER
                             Select messages after this date
       --date-before=DATE_BEFORE

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 import logging
 import os
 import re
@@ -56,9 +56,9 @@ def process_message(filename_template, options, message):
         logging.warning("Skipping message '%s' subject '%s' because it is after %s", uid, subject,
                         options.date_before)
         return
-    if options.subject_regex_match_anywhere and options.subject_regex_match_anywhere = True
-        if options.subject_regex_ignore_case and options.subject_regex_ignore_case = True
-            if options.subject_regex and not re.search(options.subject_regex, subject, flags=re.IGNORECASE):
+    if options.subject_regex_match_anywhere and options.subject_regex_match_anywhere is True:
+        if options.subject_regex_ignore_case and options.subject_regex_ignore_case is True:
+            if options.subject_regex and not re.search(options.subject_regex, subject, re.IGNORECASE):
                 logging.warning("Skipping message '%s' subject '%s' because %s (case-insensitive) was not found anywhere in the string", uid, subject,
                                 options.subject_regex)
                 return
@@ -69,7 +69,7 @@ def process_message(filename_template, options, message):
                 return
         return
     else: 
-        if options.subject_regex_ignore_case and options.subject_regex_ignore_case = true
+        if options.subject_regex_ignore_case and options.subject_regex_ignore_case is True:
             if options.subject_regex and not re.match(options.subject_regex, subject, flags=re.IGNORECASE):
                 logging.warning("Skipping message '%s' subject '%s' because it does not match %s (case-insensitive)", uid, subject,
                                 options.subject_regex)

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -67,8 +67,7 @@ def process_message(filename_template, options, message):
                 logging.warning("Skipping message '%s' subject '%s' because %s was not found anywhere in the string", uid, subject,
                                 options.subject_regex)
                 return
-        return
-    else: 
+    else:
         if options.subject_regex_ignore_case and options.subject_regex_ignore_case is True:
             if options.subject_regex and not re.match(options.subject_regex, subject, flags=re.IGNORECASE):
                 logging.warning("Skipping message '%s' subject '%s' because it does not match %s (case-insensitive)", uid, subject,
@@ -79,8 +78,6 @@ def process_message(filename_template, options, message):
                 logging.warning("Skipping message '%s' subject '%s' because it does not match %s", uid, subject,
                                 options.subject_regex)
                 return
-        return
-    return
 
     logging.info("Processing message '%s' subject '%s'", uid, subject)
 
@@ -135,8 +132,8 @@ if __name__ == '__main__':
     parser.add_option("--password", dest="password", help="IMAP Password")
     parser.add_option("--imap-folder", dest="imap_folder", help="IMAP Folder to extract attachments from")
     parser.add_option("--subject-regex", dest="subject_regex", help="Regex that the subject must match against")
-    parser.add_option("--subject-regex-ignore-case", dest="subject_regex_ignore_case", help="Ignore case in subject regex match. True/False")
-    parser.add_option("--subject-regex-match-anywhere", dest="subject_regex_match_anywhere", help="Search for regex match anywhere in subject. True/False")
+    parser.add_option("--subject-regex-ignore-case", dest="subject_regex_ignore_case", action="store_true", default=False,  help="Provide this option to ignore regex case in subject.")
+    parser.add_option("--subject-regex-match-anywhere", dest="subject_regex_match_anywhere", action="store_true", default=False, help="Provide this option to search anywhere in subject")
     parser.add_option("--date-after", dest="date_after", type='date',
                       help='Select messages after this date')
     parser.add_option("--date-before", dest="date_before",

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 import logging
 import os
 import re

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -32,13 +32,9 @@ def build_filter_options():
 
 def process_message(filename_template, options, message):
     subject = ''
-    sender = ''
 
     if hasattr(message, 'subject'):
         subject = QuoPriEncoding.decode(message.subject)
-    if hasattr(message, 'from'):
-        sender = message.sent_from
-        sender = sender.replace("@", "_")
 
     try:
         parsed_message_date = dateparser.parse(message.date)
@@ -92,7 +88,6 @@ def process_message(filename_template, options, message):
             download_filename = filename_template.render(attachment_name=attachment_filename,
                                                          attachment_idx=idx,
                                                          subject=subject,
-                                                         sender=sender
                                                          message_id=message.message_id,
                                                          date=parsed_message_date,
                                                          folder=folder)

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -135,8 +135,8 @@ if __name__ == '__main__':
     parser.add_option("--password", dest="password", help="IMAP Password")
     parser.add_option("--imap-folder", dest="imap_folder", help="IMAP Folder to extract attachments from")
     parser.add_option("--subject-regex", dest="subject_regex", help="Regex that the subject must match against")
-    parser.add_option("--subject-regex-ignore-case", dest="subject_regex_ignore_case, help="Ignore case in subject regex match. True/False")
-    parser.add_option("--subject-regex-match-anywhere", dest="subject_regex_match_anywhere, help="Search for regex match anywhere in subject. True/False")
+    parser.add_option("--subject-regex-ignore-case", dest="subject_regex_ignore_case", help="Ignore case in subject regex match. True/False")
+    parser.add_option("--subject-regex-match-anywhere", dest="subject_regex_match_anywhere", help="Search for regex match anywhere in subject. True/False")
     parser.add_option("--date-after", dest="date_after", type='date',
                       help='Select messages after this date')
     parser.add_option("--date-before", dest="date_before",

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -56,26 +56,26 @@ def process_message(filename_template, options, message):
         logging.warning("Skipping message '%s' subject '%s' because it is after %s", uid, subject,
                         options.date_before)
         return
-    if options.subject_regex_match_anywhere and options.subject_regex_match_anywhere is True:
-        if options.subject_regex_ignore_case and options.subject_regex_ignore_case is True:
+    if options.subject_regex_match_anywhere is True:
+        if options.subject_regex_ignore_case is True:
             if options.subject_regex and not re.search(options.subject_regex, subject, re.IGNORECASE):
-                logging.warning("Skipping message '%s' subject '%s' because %s (case-insensitive) was not found anywhere in the string", uid, subject,
+                logging.warning("Skipping message '%s' subject '%s' because %s (case-insensitive) was not found in the string", uid, subject,
                                 options.subject_regex)
                 return
         else:
             if options.subject_regex and not re.search(options.subject_regex, subject):
-                logging.warning("Skipping message '%s' subject '%s' because %s was not found anywhere in the string", uid, subject,
+                logging.warning("Skipping message '%s' subject '%s' because %s (case-sensitive) was not found anywhere in the string", uid, subject,
                                 options.subject_regex)
                 return
     else:
-        if options.subject_regex_ignore_case and options.subject_regex_ignore_case is True:
+        if options.subject_regex_ignore_case is True:
             if options.subject_regex and not re.match(options.subject_regex, subject, flags=re.IGNORECASE):
-                logging.warning("Skipping message '%s' subject '%s' because it does not match %s (case-insensitive)", uid, subject,
+                logging.warning("Skipping message '%s' subject '%s' because it does not start with %s (case-insensitive)", uid, subject,
                                 options.subject_regex)
                 return
         else:
             if options.subject_regex and not re.match(options.subject_regex, subject):
-                logging.warning("Skipping message '%s' subject '%s' because it does not match %s", uid, subject,
+                logging.warning("Skipping message '%s' subject '%s' because it does not start with %s (case-sensitive)", uid, subject,
                                 options.subject_regex)
                 return
 

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -56,11 +56,31 @@ def process_message(filename_template, options, message):
         logging.warning("Skipping message '%s' subject '%s' because it is after %s", uid, subject,
                         options.date_before)
         return
-
-    if options.subject_regex and not re.match(options.subject_regex, subject):
-        logging.warning("Skipping message '%s' subject '%s' because it does not match %s", uid, subject,
-                        options.subject_regex)
+    if options.subject_regex_match_anywhere and options.subject_regex_match_anywhere = True
+        if options.subject_regex_ignore_case and options.subject_regex_ignore_case = True
+            if options.subject_regex and not re.search(options.subject_regex, subject, flags=re.IGNORECASE):
+                logging.warning("Skipping message '%s' subject '%s' because %s (case-insensitive) was not found anywhere in the string", uid, subject,
+                                options.subject_regex)
+                return
+        else:
+            if options.subject_regex and not re.search(options.subject_regex, subject):
+                logging.warning("Skipping message '%s' subject '%s' because %s was not found anywhere in the string", uid, subject,
+                                options.subject_regex)
+                return
         return
+    else: 
+        if options.subject_regex_ignore_case and options.subject_regex_ignore_case = true
+            if options.subject_regex and not re.match(options.subject_regex, subject, flags=re.IGNORECASE):
+                logging.warning("Skipping message '%s' subject '%s' because it does not match %s (case-insensitive)", uid, subject,
+                                options.subject_regex)
+                return
+        else:
+            if options.subject_regex and not re.match(options.subject_regex, subject):
+                logging.warning("Skipping message '%s' subject '%s' because it does not match %s", uid, subject,
+                                options.subject_regex)
+                return
+        return
+    return
 
     logging.info("Processing message '%s' subject '%s'", uid, subject)
 
@@ -115,6 +135,8 @@ if __name__ == '__main__':
     parser.add_option("--password", dest="password", help="IMAP Password")
     parser.add_option("--imap-folder", dest="imap_folder", help="IMAP Folder to extract attachments from")
     parser.add_option("--subject-regex", dest="subject_regex", help="Regex that the subject must match against")
+    parser.add_option("--subject-regex-ignore-case", dest="subject_regex_ignore_case, help="Ignore case in subject regex match. True/False")
+    parser.add_option("--subject-regex-match-anywhere", dest="subject_regex_match_anywhere, help="Search for regex match anywhere in subject. True/False")
     parser.add_option("--date-after", dest="date_after", type='date',
                       help='Select messages after this date')
     parser.add_option("--date-before", dest="date_before",

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -32,7 +32,6 @@ def build_filter_options():
 
 def process_message(filename_template, options, message):
     subject = ''
-
     if hasattr(message, 'subject'):
         subject = QuoPriEncoding.decode(message.subject)
 

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -32,8 +32,13 @@ def build_filter_options():
 
 def process_message(filename_template, options, message):
     subject = ''
+    sender = ''
+
     if hasattr(message, 'subject'):
         subject = QuoPriEncoding.decode(message.subject)
+    if hasattr(message, 'from'):
+        sender = message.sent_from
+        sender = sender.replace("@", "_")
 
     try:
         parsed_message_date = dateparser.parse(message.date)

--- a/bin/attachment-downloader
+++ b/bin/attachment-downloader
@@ -92,6 +92,7 @@ def process_message(filename_template, options, message):
             download_filename = filename_template.render(attachment_name=attachment_filename,
                                                          attachment_idx=idx,
                                                          subject=subject,
+                                                         sender=sender
                                                          message_id=message.message_id,
                                                          date=parsed_message_date,
                                                          folder=folder)


### PR DESCRIPTION
I have added two new options for the script, "subject_regex_match_anywhere" and "subject_regex_ignore_case".

re.match() only matches against the beginning of a text string. If subject_regex_match_anywhere is provided, it instead performs a re.search()

If subject_regex_ignore_case is provided, the re.IGNORECASE flag is provided.

Not sure if it's the most efficient way, but it works. Note: I am 100% new to Python, but have some novice VBA experience.